### PR TITLE
Rewrote part of the README to explicitly state NOT to copy the `LoS-Mod_Files_X-master` folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This repository holds the Xbox 360 version of Legacy of Solaris. For more reposi
 # Usage
 If you haven't already, extract your ISO for SONIC THE HEDGEHOG using the [Sonic '06 Toolkit](https://github.com/HyperPolygon64/Sonic-06-Toolkit).
 
-To install Legacy of Solaris onto your copy of SONIC THE HEDGEHOG, you will need the [Sonic '06 Mod Manager](https://github.com/Knuxfan24/Sonic-06-Mod-Manager). Clone this repository to your drive (or just click Download ZIP) and put the Legacy of Solaris folder from the ZIP (**NOT** the `LoS-Mod_Files_X-master` folder) into your mods directory. Then check the mod in the Sonic '06 Mod Manager's mod list and click `Save, install content and launch Sonic '06`.
+To install Legacy of Solaris onto your copy of SONIC THE HEDGEHOG, you will need the [Sonic '06 Mod Manager](https://github.com/Knuxfan24/Sonic-06-Mod-Manager). Click `Code` and `Download ZIP` then put the Legacy of Solaris folder (**NOT** the `LoS-Mod_Files_X-master` folder) from the downloaded archive into your mods directory. Then check the mod in the Sonic '06 Mod Manager's mod list and click `Save, install content and launch Sonic '06`.
 
 For general, extra information on setting up SONIC THE HEDGEHOG mods, check the [Mod Manager's wiki](https://github.com/Knuxfan24/Sonic-06-Mod-Manager/wiki).
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ This repository holds the Xbox 360 version of Legacy of Solaris. For more reposi
 
 # Usage
 If you haven't already, extract your ISO for SONIC THE HEDGEHOG using the [Sonic '06 Toolkit](https://github.com/HyperPolygon64/Sonic-06-Toolkit).
+
 To install Legacy of Solaris onto your copy of SONIC THE HEDGEHOG, you will need the [Sonic '06 Mod Manager](https://github.com/Knuxfan24/Sonic-06-Mod-Manager). Clone this repository to your drive (or just click Download ZIP) and put the Legacy of Solaris folder from the ZIP (**NOT** the `LoS-Mod_Files_X-master` folder) into your mods directory. Then check the mod in the Sonic '06 Mod Manager's mod list and click `Save, install content and launch Sonic '06`.
+
 For extra information on setting up SONIC THE HEDGEHOG mods, check the [Mod Manager's wiki](https://github.com/Knuxfan24/Sonic-06-Mod-Manager/wiki).
 
 # Contributors

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ If you haven't already, extract your ISO for SONIC THE HEDGEHOG using the [Sonic
 
 To install Legacy of Solaris onto your copy of SONIC THE HEDGEHOG, you will need the [Sonic '06 Mod Manager](https://github.com/Knuxfan24/Sonic-06-Mod-Manager). Clone this repository to your drive (or just click Download ZIP) and put the Legacy of Solaris folder from the ZIP (**NOT** the `LoS-Mod_Files_X-master` folder) into your mods directory. Then check the mod in the Sonic '06 Mod Manager's mod list and click `Save, install content and launch Sonic '06`.
 
-For extra information on setting up SONIC THE HEDGEHOG mods, check the [Mod Manager's wiki](https://github.com/Knuxfan24/Sonic-06-Mod-Manager/wiki).
+For general, extra information on setting up SONIC THE HEDGEHOG mods, check the [Mod Manager's wiki](https://github.com/Knuxfan24/Sonic-06-Mod-Manager/wiki).
 
 # Contributors
 ### Main Developers

--- a/README.md
+++ b/README.md
@@ -12,12 +12,9 @@ This repository holds the Xbox 360 version of Legacy of Solaris. For more reposi
 - [Miscellaneous](https://github.com/LostLegacyTeam/LoS-Miscellaneous)
 
 # Usage
-If you haven't already, extract your ISO for SONIC THE HEDGEHOG using [Sonic '06 Toolkit](https://github.com/HyperPolygon64/Sonic-06-Toolkit).
-### Sonic '06 Mod Manager (recommended)
-To install Legacy of Solaris onto your copy of SONIC THE HEDGEHOG, you will need [Sonic '06 Mod Manager](https://github.com/Knuxfan24/Sonic-06-Mod-Manager). Clone to repository to your drive (or just click Download ZIP) and put the Legacy of Solaris folder in your mods directory. Then tick the mod from Sonic '06 Mod Manager and click Save and Play (or Install Mods for FTP).
-# Xenia
-### DirectX 12
-For DirectX 12, no additional steps are required to run Sonic '06 optimally, this branch of Xenia as of now works well with SONIC THE HEDGEHOG. However, you may notice the occasional texture memory corruptions and/or vertex explosions, if those occur please press F4.
+If you haven't already, extract your ISO for SONIC THE HEDGEHOG using the [Sonic '06 Toolkit](https://github.com/HyperPolygon64/Sonic-06-Toolkit).
+To install Legacy of Solaris onto your copy of SONIC THE HEDGEHOG, you will need the [Sonic '06 Mod Manager](https://github.com/Knuxfan24/Sonic-06-Mod-Manager). Clone this repository to your drive (or just click Download ZIP) and put the Legacy of Solaris folder from the ZIP (**NOT** the `LoS-Mod_Files_X-master` folder) into your mods directory. Then check the mod in the Sonic '06 Mod Manager's mod list and click `Save, install content and launch Sonic '06`.
+For extra information on setting up SONIC THE HEDGEHOG mods, check the [Mod Manager's wiki](https://github.com/Knuxfan24/Sonic-06-Mod-Manager/wiki).
 
 # Contributors
 ### Main Developers


### PR DESCRIPTION
Mostly because I'm getting sick of people screwing up a simple act like moving a folder out of a ZIP file.

The Xenia thing was also kind of unnecessary, so I've just replaced it with a link to the Mod Manager's Wiki for a more comprehensive overview, as the Manager will need to be setup correctly to use LoS anyway.